### PR TITLE
Add version pinning to current release for Elixir 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-wiredep",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Laravel Elixir Wiredep extension",
   "main": "index.js",
   "scripts": {
@@ -24,5 +24,8 @@
   },
   "dependencies": {
     "wiredep": "^2.2.2"
+  },
+  "peerDependencies": {
+    "laravel-elixir": "^2.0"
   }
 }


### PR DESCRIPTION
I feel that it is important to provide a way for you to upgrade or patch if bugs occur. So in preparation for the solution to #3 I propose you add version pinning. This pinning allows you to continue to support Elixir 2 under the ^0.1 versions.  It will also look for Elixir 2.0 installed, if it isn't found it will error.

Be sure to push this to a branch (I used 2.x), tag it with the version, and publish to npm from there.

In the future to push releases without changing your `latest` tagged release you can use `npm publish --tag 2.x-release`.

Readme will also need to be updated to include instructions to install for Elixir 2.x. 

It would be similar to this.:

```
npm install --save-dev laravel-elixir-wiredep@"^0.1"
```
