### PR TITLE
Add the changes suggested by killtw from #4 after applying #5 and using version pinning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var gulp = require('gulp');
 var wiredep = require('wiredep').stream;
 var elixir = require('laravel-elixir');
-var utilities = require('laravel-elixir/ingredients/commands/Utilities');
+var path = require('path');
+var task = elixir.Task;
 
 elixir.extend('wiredep', function(config, opts) {
 
@@ -11,7 +12,7 @@ elixir.extend('wiredep', function(config, opts) {
   config.baseDir = config.baseDir || 'resources/views/';
   config.src = config.src || false;
   config.searchLevel = config.searchLevel || '**/*.php';
-  
+
   opts.ignorePath = opts.ignorePath || /(\..\/)*public/;
   opts.fileTypes = opts.fileTypes || {
         php: {
@@ -27,16 +28,11 @@ elixir.extend('wiredep', function(config, opts) {
         }
       };
 
-  src = utilities.buildGulpSrc(config.src, config.baseDir, config.searchLevel);
+      new task('wiredep', function() {
+        var src = path.join(config.baseDir, !!config.src ? config.src : config.searchLevel);
 
-  gulp.task('wiredep', function() {
-    gulp.src(src)
-    .pipe(wiredep(opts))
-    .pipe(gulp.dest(config.baseDir));
-  });
-
-  this.registerWatcher('wiredep', opts.bowerJson || './bower.json');
-
-  return this.queueTask('wiredep');
+        return gulp.src(src).pipe(wiredep(opts)).pipe(gulp.dest(config.baseDir))
+      })
+      .watch(opts.bowerJson || './bower.json');
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-wiredep",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Laravel Elixir Wiredep extension",
   "main": "index.js",
   "scripts": {
@@ -24,5 +24,8 @@
   },
   "dependencies": {
     "wiredep": "^2.2.2"
+  },
+  "peerDependencies": {
+    "laravel-elixir": "^3.0"
   }
 }


### PR DESCRIPTION
Again I feel it is important to make a clear split when adding support for Elixir 3.x so you can continue to support Elixir 2.x users. This will require the version pinning handled in #5 and also a major bump before implementing @killtw's changes. 

I tried to fork form his PR but that fork is unknown and appears to be deleted, so I copied the changes and included them in here. You can keep these in `master`. But I recommend tagging the branch with the version before publishing to npm.

You will want to provide the same instruction you do now for users if they are on Elixir 3x. 
Something like this:

```
npm install --save-dev laravel-elixir-wiredep
```

It will properly warn them the peer dependencies aren't met if they either don't have elixir or have version 2.x installed instead.
