### PR TITLE
Less sass etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ elixir.extend('wiredep', function(config, opts) {
   config.src = config.src || false;
   config.searchLevel = config.searchLevel || '**/*.php';
 
-  opts.ignorePath = opts.ignorePath || /(\..\/)*public/;
+  opts.ignorePath = opts.ignorePath || /(\..\/)*(public)?/;
   opts.fileTypes = opts.fileTypes || {
         php: {
           block: /(([ \t]*)<!--\s*bower:*(\S*)\s*-->)(\n|\r|.)*?(<!--\s*endbower\s*-->)/gi,

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var wiredep = require('wiredep').stream;
 var elixir = require('laravel-elixir');
 var path = require('path');
 var task = elixir.Task;
+var econ = elixir.config;
+var merge = require('merge-stream');
 
 elixir.extend('wiredep', function(config, opts) {
 
@@ -62,13 +64,20 @@ elixir.extend('wiredep', function(config, opts) {
               sass: '@import "{{filePath}}";',
               scss: '@import "{{filePath}}";'
           }
-        }
+        },
       };
+
+      var less = path.join(econ.get('assets.less.folder'), '**/*.less');
+      var sass = path.join(econ.get('assets.sass.folder'), '**/*.sass');
+      var scss = path.join(econ.get('assets.sass.folder'), '**/*.scss');
 
       new task('wiredep', function() {
         var src = path.join(config.baseDir, !!config.src ? config.src : config.searchLevel);
-
-        return gulp.src(src).pipe(wiredep(opts)).pipe(gulp.dest(config.baseDir))
+        return merge( gulp.src(less).pipe(wiredep(opts)).pipe(gulp.dest(econ.get('assets.css.less.folder'))),
+                      gulp.src(sass).pipe(wiredep(opts)).pipe(gulp.dest(econ.get('assets.css.sass.folder'))),
+                      gulp.src(scss).pipe(wiredep(opts)).pipe(gulp.dest(econ.get('assets.css.sass.folder'))),
+                      gulp.src(src).pipe(wiredep(opts)).pipe(gulp.dest(config.baseDir))
+                    );
       })
       .watch(opts.bowerJson || './bower.json');
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,32 @@ elixir.extend('wiredep', function(config, opts) {
               css: '@import "{{filePath}}";',
               less: '@import "{{filePath}}";'
           }
+        },
+        sass: {
+          block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+          detect: {
+              css: /@import\s(.+css)/gi,
+              sass: /@import\s(.+sass)/gi,
+              scss: /@import\s(.+scss)/gi
+          },
+          replace: {
+              css: '@import {{filePath}}',
+              sass: '@import {{filePath}}',
+              scss: '@import {{filePath}}'
+          }
+        },
+        scss: {
+          block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+          detect: {
+              css: /@import\s['"](.+css)['"]/gi,
+              sass: /@import\s['"](.+sass)['"]/gi,
+              scss: /@import\s['"](.+scss)['"]/gi
+          },
+          replace: {
+              css: '@import "{{filePath}}";',
+              sass: '@import "{{filePath}}";',
+              scss: '@import "{{filePath}}";'
+          }
         }
       };
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,17 @@ elixir.extend('wiredep', function(config, opts) {
             js: '<script src="{{filePath}}"></script>',
             css: '<link rel="stylesheet" href="{{filePath}}" />'
           }
+        },
+        less: {
+          block: /(([ \t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+          detect: {
+              css: /@import\s['"](.+css)['"]/gi,
+              less: /@import\s['"](.+less)['"]/gi
+          },
+          replace: {
+              css: '@import "{{filePath}}";',
+              less: '@import "{{filePath}}";'
+          }
         }
       };
 


### PR DESCRIPTION
I think this still needs some work, but I wanted to PR to get this in front of you. I believe it will work correctly for most cases. 

This should work for users who have put their bower components in the public directory as you have, people how have left it where it was as I have. And another possible solution I think exists which is symlinking to public. 

I need to test your scenario with the scss file. 

Right now I am testing a minimal use case (bootstrap) and have the following:

/resources/assets/sass/app.scss

```
// bower:scss
// endbower
```

/bower.json

```
{
  "name": "codes",
  "version": "0.0.0",
  "dependencies": {
    "bootstrap-sass-official": "~3.3",
    "modernizr": "~2.6.2",
    "jquery": "~2.1.0"
  },
  "overrides": {
    "bootstrap-sass-official": {
      "main": [
        "./assets/stylesheets/_bootstrap.scss",
        "./assets/fonts/bootstrap/glyphicons-halflings-regular.eot",
        "./assets/fonts/bootstrap/glyphicons-halflings-regular.svg",
        "./assets/fonts/bootstrap/glyphicons-halflings-regular.ttf",
        "./assets/fonts/bootstrap/glyphicons-halflings-regular.woff",
        "./assets/fonts/bootstrap/glyphicons-halflings-regular.woff2",
        "./assets/javascripts/bootstrap.js"
      ]
    }
  }
}
```

This should result in 

/resources/assets/sass/app.scss

```
// bower:scss
@import "bower_modules/bootstrap-sass-official/assets/stylesheets/_bootstrap.scss";
// endbower

after running gulp, but I think in your case it really should produce `@import "public/bower_modules/bootstrap-sass-official/assets/stylesheets/_bootstrap.scss";`

I am unsure.
```
